### PR TITLE
Fix build to run tests

### DIFF
--- a/bundles/org.eclipse.releng.tools.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.releng.tools.tests/META-INF/MANIFEST.MF
@@ -7,7 +7,6 @@ Eclipse-BundleShape: dir
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime,
- org.junit,
  junit-jupiter-api,
  org.eclipse.jgit;bundle-version="3.0.0";resolution:=optional,
  org.eclipse.core.resources,

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   </prerequisites>
 
   <properties>
-    <tycho.version>2.7.4</tycho.version>
+    <tycho.version>3.0.0-SNAPSHOT</tycho.version>
     <cbi-plugins.version>1.3.2</cbi-plugins.version>
     <maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
     <buildTimestamp>${maven.build.timestamp}</buildTimestamp>
@@ -80,6 +80,16 @@
       <url>${cbi-snapshots-repo.url}</url>
       <releases>
         <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </pluginRepository>
+    <pluginRepository>
+      <id>tycho-snapshots</id>
+      <url>https://repo.eclipse.org/content/repositories/tycho-snapshots/</url>
+      <releases>
+        <enabled>true</enabled>
       </releases>
       <snapshots>
         <enabled>true</enabled>


### PR DESCRIPTION
Tycho 3.0.0-SNAPSHOT is needed for the fix to use upstream JUnit
symbolic names.