### PR TITLE
Some comparator errors are not detected

### DIFF
--- a/bundles/org.eclipse.releng.build.tools.comparator/src/org/eclipse/releng/build/tools/comparator/Extractor.java
+++ b/bundles/org.eclipse.releng.build.tools.comparator/src/org/eclipse/releng/build/tools/comparator/Extractor.java
@@ -61,7 +61,7 @@ public class Extractor {
 	private String outputFilenameOtherLog;
 	private String outputFilenameSignPlusInnerJarLog;
 	private String outputFilenamejdtCoreLog;
-	private final String mainregexPattern = "^\\[WARNING\\].*eclipse.platform.releng.aggregator/(.*)/pom.xml: baseline and build artifacts have same version but different contents";
+	private final String mainregexPattern = "^\\[WARNING\\].*eclipse.platform.releng.aggregator/(.*): baseline and build artifacts have same version but different contents";
 	private final Pattern mainPattern = Pattern.compile(mainregexPattern);
 	private final String noclassifierregexPattern = "^.*no-classifier:.*$";
 	private final Pattern noclassifierPattern = Pattern.compile(noclassifierregexPattern);


### PR DESCRIPTION
To detect comparator error we are looking for
^\\[WARNING\\].*eclipse.platform.releng.aggregator/(.*)/pom.xml:
baseline and build artifacts have same version but different contents";
but with pomless build we don't have pom.xml had to adjust the pattern
here

Fixes 
https://github.com/eclipse-platform/eclipse.platform.releng.buildtools/issues/5