### PR TITLE
Avoid String.toLowerCase() using equalsIgnoreCase

### DIFF
--- a/bundles/org.eclipse.build.tools/src/org/eclipse/releng/UnpackUpdateJars.java
+++ b/bundles/org.eclipse.build.tools/src/org/eclipse/releng/UnpackUpdateJars.java
@@ -172,7 +172,7 @@ public class UnpackUpdateJars extends Task {
                 continue;
             }
 
-            if (unpackNode.getNodeValue().toString().trim().toLowerCase().equals("true")) {
+            if (Boolean.parseBoolean(unpackNode.getNodeValue().toString().trim())) {
                 if (!unpackedPlugins.contains(pluginDirName)) {
                     System.out.println(pluginDirName);
                     unpackedPlugins.add(pluginDirName);


### PR DESCRIPTION
Code cleanup