### PR TITLE
Remove blank Javadoc

### DIFF
--- a/bundles/org.eclipse.build.tools/src/org/eclipse/releng/ElementParser.java
+++ b/bundles/org.eclipse.build.tools/src/org/eclipse/releng/ElementParser.java
@@ -8,7 +8,6 @@
  *******************************************************************************/
 /**
  * Parses feature.xml, plugin.xml, and fragment.xml files
- * 
  */
 
 package org.eclipse.releng;

--- a/bundles/org.eclipse.build.tools/src/org/eclipse/releng/generators/TestResultsGenerator.java
+++ b/bundles/org.eclipse.build.tools/src/org/eclipse/releng/generators/TestResultsGenerator.java
@@ -556,9 +556,6 @@ public class TestResultsGenerator extends Task {
         return dropTokenList;
     }
 
-    /**
-     * @return
-     */
     public Vector<String> getDropTokens() {
         return dropTokens;
     }
@@ -607,16 +604,10 @@ public class TestResultsGenerator extends Task {
         return testResultsHtmlFileName;
     }
 
-    /**
-     * @return
-     */
     public String getTestResultsWithProblems() {
         return testResultsWithProblems;
     }
 
-    /**
-     * @return
-     */
     public String getTestResultsXmlUrls() {
         return testResultsXmlUrls;
     }
@@ -1169,9 +1160,6 @@ public class TestResultsGenerator extends Task {
         this.dropTokenList = dropTokenList;
     }
 
-    /**
-     * @param vector
-     */
     public void setDropTokens(final Vector<String> vector) {
         dropTokens = vector;
     }
@@ -1218,9 +1206,6 @@ public class TestResultsGenerator extends Task {
         testResultsHtmlFileName = aString;
     }
 
-    /**
-     * @param string
-     */
     public void setTestResultsWithProblems(final String string) {
         testResultsWithProblems = string;
     }
@@ -1314,8 +1299,6 @@ public class TestResultsGenerator extends Task {
      * This method writes the computed HTML to the file specified by caller in
      * testResultsHtmlFileName. There must be an appropriate file on Download
      * site that "includes" the file.
-     *
-     * @param contents
      */
     private void writeTestResultsFile(String contents) {
         final String outputFileName = dropDirectoryName + File.separator + testResultsHtmlFileName;

--- a/bundles/org.eclipse.releng.build.tools.comparator/src/org/eclipse/releng/build/tools/comparator/Extractor.java
+++ b/bundles/org.eclipse.releng.build.tools.comparator/src/org/eclipse/releng/build/tools/comparator/Extractor.java
@@ -18,7 +18,6 @@ import java.util.regex.Pattern;
  * the huge maven debug log.
  * 
  * @author davidw
- * 
  */
 public class Extractor {
 

--- a/bundles/org.eclipse.releng.tools.tests/src/org/eclipse/releng/tests/tools/LocalGitRepositoryTestData.java
+++ b/bundles/org.eclipse.releng.tools.tests/src/org/eclipse/releng/tests/tools/LocalGitRepositoryTestData.java
@@ -121,7 +121,6 @@ public abstract class LocalGitRepositoryTestData {
 	 *            true for a bare repository; false for a repository with a
 	 *            working directory
 	 * @return a unique directory for a test repository
-	 * @throws IOException
 	 */
 	protected File createUniqueTestGitDir(boolean bare) throws IOException {
 		String gitdirName = createUniqueTestFolderPrefix();

--- a/bundles/org.eclipse.releng.tools/src/org/eclipse/releng/internal/tools/pomversion/PomVersionErrorReporter.java
+++ b/bundles/org.eclipse.releng.tools/src/org/eclipse/releng/internal/tools/pomversion/PomVersionErrorReporter.java
@@ -61,7 +61,6 @@ import org.xml.sax.helpers.DefaultHandler;
 /**
  * Validates the content of the pom.xml.  Currently the only check is that the
  * version specified in pom.xml matches the bundle version.
- *
  */
 public class PomVersionErrorReporter implements IResourceChangeListener, IEclipsePreferences.IPreferenceChangeListener {
 
@@ -316,8 +315,6 @@ public class PomVersionErrorReporter implements IResourceChangeListener, IEclips
 
 	/**
 	 * Clean up all markers
-	 *
-	 * @param project
 	 */
 	void cleanMarkers(IResource resource) {
 		try {
@@ -330,9 +327,6 @@ public class PomVersionErrorReporter implements IResourceChangeListener, IEclips
 
 	/**
 	 * Validates the manifest or feature version against the version in the <code>pom.xml</code> file
-	 *
-	 * @param project
-	 * @param severity
 	 */
 	public void validate(IProject project) {
 		if(project == null || !project.isAccessible()) {
@@ -456,7 +450,6 @@ public class PomVersionErrorReporter implements IResourceChangeListener, IEclips
 	 * is returned if the {@link IFile} does not exist or the {@link ITextFileBufferManager}
 	 * cannot be acquired or there was an exception trying to create the {@link IDocument}.
 	 *
-	 * @param file
 	 * @return a new {@link IDocument} or <code>null</code>
 	 */
 	protected IDocument createDocument(IFile file) {

--- a/bundles/org.eclipse.releng.tools/src/org/eclipse/releng/tools/AdvancedCopyrightComment.java
+++ b/bundles/org.eclipse.releng.tools/src/org/eclipse/releng/tools/AdvancedCopyrightComment.java
@@ -35,7 +35,6 @@ import org.eclipse.releng.tools.preferences.RelEngCopyrightConstants;
  * Tested in {@link org.eclipse.releng.tests.AdvancedCopyrightCommentTestsJunit4}<br>
  * Please verify that tests run after modifications.
  * </p>
- *
  */
 public class AdvancedCopyrightComment extends CopyrightComment {
 
@@ -125,7 +124,6 @@ public class AdvancedCopyrightComment extends CopyrightComment {
 	 * @param commentStyle
 	 *            the comment style. {@link CopyrightComment}
 	 * @return {@link AdvancedCopyrightComment} an copyright comment with the year updated.
-	 *
 	 */
 	public static AdvancedCopyrightComment parse(BlockComment commentBock, int commentStyle) {
 		// If the given comment is empty, return the default comment.
@@ -266,9 +264,6 @@ public class AdvancedCopyrightComment extends CopyrightComment {
 	/**
 	 * Write out the copyright statement, line by line, adding in the created/revision
 	 * year as well as comment line prefixes.
-	 *
-	 * @param writer
-	 * @param linePrefix
 	 */
 	private void writeLegal(PrintWriter writer, String linePrefix) {
 		String[] legalLines = getLegalLines();
@@ -334,10 +329,6 @@ public class AdvancedCopyrightComment extends CopyrightComment {
 	 * <p>
 	 * This should <b>only</b> be used for lines that have a single year.
 	 * </p>
-	 *
-	 * @param line
-	 * @param year
-	 * @return
 	 */
 	private static String insertRevisedYear(String line, int year) {
 		Matcher matcher = Pattern.compile(YEAR_REGEX).matcher(line);
@@ -355,9 +346,6 @@ public class AdvancedCopyrightComment extends CopyrightComment {
 
 	/**
 	 * Given a line with one or multiple years on it, count how many years occur on it.
-	 *
-	 * @param line
-	 * @return
 	 */
 	private static int countYearsOnLine(String line) {
 		Matcher yearMatcher = Pattern.compile(YEAR_REGEX).matcher(line);
@@ -391,7 +379,6 @@ public class AdvancedCopyrightComment extends CopyrightComment {
 	 * in the range YEAR_REGEX
 	 *
 	 * @see #YEAR_REGEX
-	 * @param line
 	 * @return e.g 2011
 	 */
 	private static int getLastYear(String line) {

--- a/bundles/org.eclipse.releng.tools/src/org/eclipse/releng/tools/AdvancedFixCopyrightAction.java
+++ b/bundles/org.eclipse.releng.tools/src/org/eclipse/releng/tools/AdvancedFixCopyrightAction.java
@@ -296,9 +296,6 @@ public class AdvancedFixCopyrightAction implements IObjectActionDelegate {
 		return factory.createAdapater(results);
 	}
 
-	/**
-	 *
-	 */
 	private void writeLogs() {
 
 		FileOutputStream aStream;
@@ -360,8 +357,6 @@ public class AdvancedFixCopyrightAction implements IObjectActionDelegate {
 	 *
 	 * @param file
 	 *            - file to be proccessed (.java, .bat, .xml etc...)
-	 * @param adapter
-	 * @param monitor
 	 */
 	private void processFile(IFile file, RepositoryProviderCopyrightAdapter adapter, IProgressMonitor monitor) {
 
@@ -543,8 +538,6 @@ public class AdvancedFixCopyrightAction implements IObjectActionDelegate {
 	/**
 	 * Check if the file has multiple copyright notices. Skip such files.
 	 *
-	 * @param file
-	 * @param aSourceFile
 	 * @return true if it has a single notice.
 	 */
 	private boolean checkMultipleCopyright(IFile file, SourceFile aSourceFile) {

--- a/bundles/org.eclipse.releng.tools/src/org/eclipse/releng/tools/BlockComment.java
+++ b/bundles/org.eclipse.releng.tools/src/org/eclipse/releng/tools/BlockComment.java
@@ -24,11 +24,6 @@ public class BlockComment {
 	private String copyrightHolder;
 
 
-	/**
-	 * @param commentStart
-	 * @param commentEnd
-	 * @param comment
-	 */
 	public BlockComment(int commentStartLine, int commentEndLine, String comment) {
 		start = commentStartLine;
 		end = commentEndLine;

--- a/bundles/org.eclipse.releng.tools/src/org/eclipse/releng/tools/CopyrightComment.java
+++ b/bundles/org.eclipse.releng.tools/src/org/eclipse/releng/tools/CopyrightComment.java
@@ -119,7 +119,6 @@ public abstract class CopyrightComment {
 	}
 
 	/**
-	 * @param lineDelimiter
 	 * @since 3.7
 	 */
 	public void setLineDelimiter(String lineDelimiter) {

--- a/bundles/org.eclipse.releng.tools/src/org/eclipse/releng/tools/IRepositoryProviderCopyrightAdapterFactory.java
+++ b/bundles/org.eclipse.releng.tools/src/org/eclipse/releng/tools/IRepositoryProviderCopyrightAdapterFactory.java
@@ -21,7 +21,6 @@ import org.eclipse.core.runtime.IAdapterManager;
  * that can be used by the {@link AdvancedFixCopyrightAction} to determine the last modified year
  * for a set of files. It should be obtained by adapting the repository provider type to an instance
  * of this interface using the {@link IAdapterManager}.
- *
  */
 public interface IRepositoryProviderCopyrightAdapterFactory {
 

--- a/bundles/org.eclipse.releng.tools/src/org/eclipse/releng/tools/JavaFile.java
+++ b/bundles/org.eclipse.releng.tools/src/org/eclipse/releng/tools/JavaFile.java
@@ -18,9 +18,6 @@ import org.eclipse.core.resources.IFile;
 
 public class JavaFile extends SourceFile {
 
-	/**
-	 * @param file
-	 */
 	public JavaFile(IFile file) {
 		super(file);
 	}

--- a/bundles/org.eclipse.releng.tools/src/org/eclipse/releng/tools/PropertiesFile.java
+++ b/bundles/org.eclipse.releng.tools/src/org/eclipse/releng/tools/PropertiesFile.java
@@ -18,9 +18,6 @@ import org.eclipse.core.resources.IFile;
 
 public class PropertiesFile extends SourceFile {
 
-	/**
-	 * @param file
-	 */
 	public PropertiesFile(IFile file) {
 		super(file);
 	}

--- a/bundles/org.eclipse.releng.tools/src/org/eclipse/releng/tools/RepositoryProviderCopyrightAdapter.java
+++ b/bundles/org.eclipse.releng.tools/src/org/eclipse/releng/tools/RepositoryProviderCopyrightAdapter.java
@@ -43,7 +43,6 @@ public abstract class RepositoryProviderCopyrightAdapter {
 	 * @param file the file
 	 * @param monitor a progress monitor
 	 * @return the last modified year or -1
-	 * @throws CoreException
 	 */
 	public abstract int getLastModifiedYear(IFile file, IProgressMonitor monitor) throws CoreException;
 

--- a/bundles/org.eclipse.releng.tools/src/org/eclipse/releng/tools/SourceFile.java
+++ b/bundles/org.eclipse.releng.tools/src/org/eclipse/releng/tools/SourceFile.java
@@ -185,7 +185,6 @@ public abstract class SourceFile {
 	 * If this method is called, <b>ensure</b> that you close the file buffer after usage. <br>
 	 * Otherwise you leave a memory leak. {@link #closeFileBuffer()}
 	 * {@code textFileBufferManager.disconnect(file.getFullPath(), LocationKind.IFILE, null); }
-	 * @return
 	 */
 	private ITextFileBuffer openFileBuffer() {
 		try {
@@ -261,7 +260,6 @@ public abstract class SourceFile {
 	}
 
 	/**
-	 * @param aCommet
 	 * @param newCopyrightComment          Comment to be inserted.
 	 */
 	public void replace(BlockComment aComment, String newCopyrightComment) {

--- a/bundles/org.eclipse.releng.tools/src/org/eclipse/releng/tools/XmlFile.java
+++ b/bundles/org.eclipse.releng.tools/src/org/eclipse/releng/tools/XmlFile.java
@@ -40,7 +40,6 @@ import org.eclipse.jface.text.IDocument;
  * [x] Document with XML header, copyright on 2nd line, stuff.
  * [x] test with non-IBM header.
  * 2014.07.15 tested.
- *
  */
 
 /**
@@ -150,9 +149,6 @@ public class XmlFile extends SourceFile {
 
 	/**
 	 * Given the document, find the place after the xml header to insert the comment.
-	 * @param document
-	 * @return
-	 * @throws BadLocationException
 	 */
 	private int findInsertOffset(IDocument document) throws BadLocationException {
 		boolean inInstruction = false;
@@ -212,9 +208,7 @@ public class XmlFile extends SourceFile {
 	 * {@literal<?xml version="1.0" encoding="UTF-8" standalone="no"?> } <br>
 	 * {@literal <?xml version="1.0" ?> } </p>
 	 *
-	 * @param xmlDoc
 	 * @return             True if it contains a header.
-	 * @throws BadLocationException
 	 */
 	public boolean containsXmlEncoding(IDocument xmlDoc) throws BadLocationException {
 

--- a/bundles/org.eclipse.releng.tools/src/org/eclipse/releng/tools/preferences/CopyrightPreferencePage.java
+++ b/bundles/org.eclipse.releng.tools/src/org/eclipse/releng/tools/preferences/CopyrightPreferencePage.java
@@ -297,8 +297,6 @@ public class CopyrightPreferencePage extends PreferencePage implements IWorkbenc
 
 	/**
 	 * Fix up line delimiters in doc to use only \n
-	 * @param doc
-	 * @return
 	 */
 	private String fixupLineDelimiters(IDocument doc) {
 		String docContents = doc.get();

--- a/bundles/org.eclipse.releng.tools/src/org/eclipse/releng/tools/preferences/PomErrorLevelBlock.java
+++ b/bundles/org.eclipse.releng.tools/src/org/eclipse/releng/tools/preferences/PomErrorLevelBlock.java
@@ -42,7 +42,6 @@ import org.osgi.service.prefs.BackingStoreException;
 
 /**
  * This block is used to add error/warning combos to the {@link PomVersionPreferencePage}
- *
  */
 public class PomErrorLevelBlock extends ConfigurationBlock {
 	/**
@@ -54,8 +53,6 @@ public class PomErrorLevelBlock extends ConfigurationBlock {
 
 		/**
 		 * Constructor
-		 * @param key
-		 * @param values
 		 */
 		public ControlData(Key key, String[] values) {
 			this.key = key;
@@ -97,8 +94,6 @@ public class PomErrorLevelBlock extends ConfigurationBlock {
 
 		/**
 		 * Constructor
-		 * @param qualifier
-		 * @param key
 		 */
 		public Key(String qualifier, String key) {
 			this.qualifier= qualifier;
@@ -107,8 +102,6 @@ public class PomErrorLevelBlock extends ConfigurationBlock {
 
 		/**
 		 * Returns the {@link IEclipsePreferences} node for the given context and {@link IWorkingCopyManager}
-		 * @param context
-		 * @param manager
 		 * @return the {@link IEclipsePreferences} node or <code>null</code>
 		 */
 		private IEclipsePreferences getNode(IScopeContext context, IWorkingCopyManager manager) {
@@ -121,8 +114,6 @@ public class PomErrorLevelBlock extends ConfigurationBlock {
 
 		/**
 		 * Returns the value stored in the {@link IEclipsePreferences} node from the given context and working copy manager
-		 * @param context
-		 * @param manager
 		 * @return the value from the {@link IEclipsePreferences} node or <code>null</code>
 		 */
 		public String getStoredValue(IScopeContext context, IWorkingCopyManager manager) {
@@ -136,9 +127,6 @@ public class PomErrorLevelBlock extends ConfigurationBlock {
 		/**
 		 * Returns the stored value of this {@link IEclipsePreferences} node using a given lookup order, and allowing the
 		 * top scope to be ignored
-		 * @param lookupOrder
-		 * @param ignoreTopScope
-		 * @param manager
 		 * @return the value from the {@link IEclipsePreferences} node or <code>null</code>
 		 */
 		public String getStoredValue(IScopeContext[] lookupOrder, boolean ignoreTopScope, IWorkingCopyManager manager) {
@@ -153,9 +141,6 @@ public class PomErrorLevelBlock extends ConfigurationBlock {
 
 		/**
 		 * Sets the value of this key
-		 * @param context
-		 * @param value
-		 * @param manager
 		 */
 		public void setStoredValue(IScopeContext context, String value, IWorkingCopyManager manager) {
 			IEclipsePreferences node = getNode(context, manager);
@@ -242,7 +227,6 @@ public class PomErrorLevelBlock extends ConfigurationBlock {
 
 	/**
 	 * Constructor
-	 * @param project
 	 */
 	public PomErrorLevelBlock(IWorkbenchPreferenceContainer container) {
 		fLookupOrder = new IScopeContext[] {
@@ -347,9 +331,6 @@ public class PomErrorLevelBlock extends ConfigurationBlock {
 
 	/**
 	 * Creates a {@link Label} | {@link Combo} control. The combo is initialised from the given {@link Key}
-	 * @param parent
-	 * @param label
-	 * @param key
 	 */
 	protected Combo createComboControl(Composite parent, String label, Key key) {
 		Label lbl = new Label(parent, SWT.NONE);


### PR DESCRIPTION
This commit cleans up Javadoc that does not add information. It resolves ecj warnings:
 `Javadoc: Description expected after ...`
It helps to prevent future empty javadoc by disabling missingJavaDoc warnings. This resolves
 `Javadoc: Missing ...`

The modification is a result of regular expression search&replace:

in files `*.java`
 `^[\s]*\*[\s]*(@return|@param[\s]*[^\s]+|@throws[\s]*[^\s]+)\R([\s]*\*[\s]*@|[\s]*\*/\R)`
 ->`$2`
 `^([\s]*\*[\s]*\R)([\s]*\*/\R)`
 ->`$2`
 `^[\S\t]*/\*\*\R[\s]*\*/\R`
 ->``

in files `org.eclipse.jdt.core.prefs`
 `org\.eclipse\.jdt\.core\.compiler\.problem\.missingJavadoc(Comments|Tags)\=[^\s]*`
 ->`org\.eclipse\.jdt\.core\.compiler\.problem\.missingJavadoc$1\=ignore`