### PR TITLE
declare org.eclipse.releng.tools.tests as friend

### DIFF
--- a/bundles/org.eclipse.releng.tools.tests/src/org/eclipse/releng/tests/tools/GitCopyrightAdapterTest.java
+++ b/bundles/org.eclipse.releng.tools.tests/src/org/eclipse/releng/tests/tools/GitCopyrightAdapterTest.java
@@ -30,7 +30,6 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.egit.core.op.ConnectProviderOperation;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.PersonIdent;
@@ -142,8 +141,9 @@ class GitCopyrightAdapterTest extends LocalGitRepositoryTestData {
 		return project;
 	}
 
+	@SuppressWarnings("restriction")
 	private void connect() throws CoreException {
-		new ConnectProviderOperation(project, gitDir).execute(null);
+		new org.eclipse.egit.core.op.ConnectProviderOperation(project, gitDir).execute(null);
 	}
 
 	private Date getDateForYear(int year) throws ParseException {

--- a/bundles/org.eclipse.releng.tools/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.releng.tools/META-INF/MANIFEST.MF
@@ -26,7 +26,7 @@ Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: 
  org.eclipse.releng.tools,
- org.eclipse.releng.tools.git;x-friends:="org.eclipse.releng.tests",
+ org.eclipse.releng.tools.git;x-friends:="org.eclipse.releng.tests, org.eclipse.releng.tools.tests",
  org.eclipse.releng.tools.preferences,
  org.eclipse.releng.internal.tools.pomversion;x-internal:=true
 Automatic-Module-Name: org.eclipse.releng.tools


### PR DESCRIPTION
to reduce warnings