### PR TITLE
Remove Maven prerequisite

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,9 +18,6 @@
   <artifactId>eclipse.platform.releng.buildtools</artifactId>
   <version>1.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
-  <prerequisites>
-    <maven>3.9.0</maven>
-  </prerequisites>
 
   <properties>
     <tycho.version>4.0.6</tycho.version>

--- a/pom.xml
+++ b/pom.xml
@@ -26,11 +26,6 @@
     <buildTimestamp>${maven.build.timestamp}</buildTimestamp>
     <buildType>I</buildType>
     <buildId>${buildType}${buildTimestamp}</buildId>
-
-    <maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
-    <buildTimestamp>${maven.build.timestamp}</buildTimestamp>
-    <buildType>I</buildType>
-    <buildId>${buildType}${buildTimestamp}</buildId>
     <comparator.repo>https://download.eclipse.org/eclipse/updates/I-builds/</comparator.repo>
     <egit-repo.url>http://download.eclipse.org/egit/updates</egit-repo.url>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Fixes
```
[WARNING] The project
org.eclipse.platform:eclipse.platform.releng.buildtools:pom:1.1.0-SNAPSHOT
uses prerequisites which is only intended for maven-plugin projects but
not for non maven-plugin projects. For such purposes you should use the
maven-enforcer-plugin. See
https://maven.apache.org/enforcer/enforcer-rules/requireMavenVersion.html
```