### PR TITLE
Allow Converter to fetch jdt's dot.xml dtd

### DIFF
--- a/bundles/org.eclipse.releng.build.tools.convert/src/org/eclipse/releng/build/tools/convert/ant/Converter.java
+++ b/bundles/org.eclipse.releng.build.tools.convert/src/org/eclipse/releng/build/tools/convert/ant/Converter.java
@@ -9,7 +9,6 @@
 
 package org.eclipse.releng.build.tools.convert.ant;
 
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
@@ -208,7 +207,10 @@ public class Converter {
 		factory.setValidating(validation);
 		factory.setIgnoringElementContentWhitespace(true);
 		final DocumentBuilder builder = factory.newDocumentBuilder();
-		builder.setEntityResolver((publicId, systemId) -> new InputSource(new ByteArrayInputStream(new byte[0])));
+		// Commented due to
+		// https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1943
+		// builder.setEntityResolver((publicId, systemId) -> new InputSource(new
+		// ByteArrayInputStream(new byte[0])));
 
         final String inputSourceOption = options.get(INPUT_SOURCE);
         if (options.get(RECURSIVE) != null) {


### PR DESCRIPTION
`As` dot.xml files are generated inside EF infra, stored there and converter run there - there should be no security concern over fetching a dtd (coming from EF too).
Fixes https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1943