### PR TITLE
[I-Build] Fix test result configuration head-line break-up

### DIFF
--- a/bundles/org.eclipse.build.tools/src/org/eclipse/releng/generators/TestResultsGenerator.java
+++ b/bundles/org.eclipse.build.tools/src/org/eclipse/releng/generators/TestResultsGenerator.java
@@ -895,7 +895,7 @@ public class TestResultsGenerator extends Task {
      */
     private String computeDisplayConfig(String config) {
         int lastUnderscore = config.lastIndexOf("_");
-        int firstUnderscore = config.indexOf('_');
+        int firstUnderscore = config.indexOf('_', config.indexOf("x86_64") + 6);
         // echo "<br/>DEBUG: config: config firstUnderscore: firstUnderscore
         // lastUnderscore: lastUnderscore lastMinusFirst: platformLength"
         String jobname = config.substring(0, firstUnderscore);


### PR DESCRIPTION
The underscore in 'x86_64' is still part of the first part, the 'job-name' part, of the configuration label.
Therefore the only the first underscore after x86_64 should be considered as delimiter.

Part of https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2494

This should fix the labels, for example at https://download.eclipse.org/eclipse/downloads/drops4/I20241028-1800/testResults.php.
Currently they are broken wrongly:

![grafik](https://github.com/user-attachments/assets/0db7d8c1-15e9-4df0-830c-b5f26a3dbe08)
