### PR TITLE
[Build] Deploy into distinct p2-repositories per buildtools version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
 		disableConcurrentBuilds(abortPrevious: true)
 	}
 	agent {
-		label "ubuntu-latest"
+		label 'ubuntu-latest'
 	}
 	tools {
 		maven 'apache-maven-latest'
@@ -32,11 +32,32 @@ pipeline {
 			when {
 				branch 'master'
 			}
+			environment {
+				EP_BUILDTOOLS_UPDATES = '/home/data/httpd/download.eclipse.org/eclipse/updates/buildtools'
+			}
 			steps {
 				sshagent ( ['projects-storage.eclipse.org-bot-ssh']) {
-					sh 'ssh genie.platform@projects-storage.eclipse.org rm -rf /home/data/httpd/download.eclipse.org/eclipse/updates/buildtools/snapshots'
-					sh 'ssh genie.platform@projects-storage.eclipse.org mkdir -p //home/data/httpd/download.eclipse.org/eclipse/updates/buildtools/snapshots'
-					sh 'scp -r repository/target/repository/* genie.platform@projects-storage.eclipse.org://home/data/httpd/download.eclipse.org/eclipse/updates/buildtools/snapshots'
+					sh '''
+						#Determine buildtools version
+						mvn help:evaluate -Dexpression=project.version --quiet '-Doutput=projectVersion-value.txt'
+						buildtoolsVersion=$(<projectVersion-value.txt)
+						rm -f projectVersion-value.txt
+						buildtoolsVersion=${buildtoolsVersion%-SNAPSHOT}
+						
+						epRepoDir="${EP_BUILDTOOLS_UPDATES}/${buildtoolsVersion}"
+						ssh genie.platform@projects-storage.eclipse.org rm -rf "${epRepoDir}"
+						ssh genie.platform@projects-storage.eclipse.org mkdir -p "${epRepoDir}"
+						scp -r repository/target/repository/* genie.platform@projects-storage.eclipse.org:"${epRepoDir}"
+						
+						# Update the composite to contain this latest deployment
+						mvn tycho-p2-repository:modify-composite-repository -Pp2-repository-modification \\
+							-Dp2.repository.location=https://download.eclipse.org/eclipse/updates/buildtools/ \\
+							-Dp2.repository.output=target/latest-composite \\
+							-Dp2.composite.children.add=${buildtoolsVersion} \\
+							-Dp2.composite.children.limit=1 \\
+							-Dp2.repository.name='Latest Eclipse RelEng Build Tools'
+						scp -r target/latest-composite/* genie.platform@projects-storage.eclipse.org:"${EP_BUILDTOOLS_UPDATES}"
+					'''
 				}
 			}
 		}

--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,11 @@
             </archive>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-help-plugin</artifactId>
+          <version>3.5.1</version>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>
@@ -217,6 +222,24 @@
             </configuration>
           </plugin>
         </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>p2-repository-modification</id>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.eclipse.tycho</groupId>
+              <artifactId>tycho-p2-repository-plugin</artifactId>
+              <configuration><!-- Properties will be defined on the CLI. -->
+                <repository>
+                  <url>${p2.repository.location}</url>
+                </repository>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
       </build>
     </profile>
   </profiles>


### PR DESCRIPTION
and reference the current one in the container composite repository, in order to make it also a 'latest' repository.

In order to create a new version (with separate repository) and to therefore retain the previous state in a p2-repo, one just has to increase the version of the root pom.xml.

With that in please we can now finally delete (with a clear conscience) the old jobs in the RelEng JIPP to deploy this repository's builds:
- https://ci.eclipse.org/releng/job/EclipseBuildTools/
- https://ci.eclipse.org/releng/job/ep-deploy-build-tools/

And the moment we only have a direct deployment of the master into one snapshot repository.
But as I plan to make more and more content of this repository obsolete by migrating the relevant parts into the `eclipse.platform.releng.aggregator`, I think it would be good to have a simple way to preserve the old states as P2 repository.

